### PR TITLE
Fix "itemtype" property name

### DIFF
--- a/Import/SharePointConfiguration/SharePointConfiguration/Import/Form/labs_SharePointConfiguration.xml
+++ b/Import/SharePointConfiguration/SharePointConfiguration/Import/Form/labs_SharePointConfiguration.xml
@@ -34,27 +34,6 @@
       <y>100</y>
       <name>client_id</name>
      </Item>
-     <Item type="Field" id="9D1DB827227C40B69CFFB1BD6D146F1F" action="add">
-      <border_width>0</border_width>
-      <display_length_unit>px</display_length_unit>
-      <field_type>item</field_type>
-      <font_color>#000000</font_color>
-      <font_family>arial, helvetica, sans-serif</font_family>
-      <font_size>8pt</font_size>
-      <font_weight>bold</font_weight>
-      <is_disabled>0</is_disabled>
-      <is_visible>1</is_visible>
-      <label xml:lang="en">ItemType</label>
-      <label_position>top</label_position>
-      <list_no_blank>0</list_no_blank>
-      <sort_order>128</sort_order>
-      <source_id keyed_name="420C91AF6E1243F1AE3A03ABF54F439A" type="Body">420C91AF6E1243F1AE3A03ABF54F439A</source_id>
-      <tab_index>128</tab_index>
-      <tab_stop>1</tab_stop>
-      <x>10</x>
-      <y>190</y>
-      <name>itemtype</name>
-     </Item>
      <Item type="Field" id="9EC5FF688CF6499EA092E69F60D64218" action="add">
       <border_width>0</border_width>
       <display_length>150</display_length>
@@ -76,6 +55,28 @@
       <x>160</x>
       <y>190</y>
       <name>itemtype_class</name>
+     </Item>
+     <Item type="Field" id="9D1DB827227C40B69CFFB1BD6D146F1F" action="add">
+      <border_width>0</border_width>
+      <display_length_unit>px</display_length_unit>
+      <field_type>item</field_type>
+      <font_color>#000000</font_color>
+      <font_family>arial, helvetica, sans-serif</font_family>
+      <font_size>8pt</font_size>
+      <font_weight>bold</font_weight>
+      <is_disabled>0</is_disabled>
+      <is_visible>1</is_visible>
+      <label xml:lang="en">ItemType</label>
+      <label_position>top</label_position>
+      <list_no_blank>0</list_no_blank>
+      <propertytype_id keyed_name="mapped_itemtype" type="Property">CD947131E8CF4B76A4DE8146D1C7FD18</propertytype_id>
+      <sort_order>128</sort_order>
+      <source_id keyed_name="420C91AF6E1243F1AE3A03ABF54F439A" type="Body">420C91AF6E1243F1AE3A03ABF54F439A</source_id>
+      <tab_index>128</tab_index>
+      <tab_stop>1</tab_stop>
+      <x>10</x>
+      <y>190</y>
+      <name>mapped_itemtype</name>
      </Item>
      <Item type="Field" id="1EB79F609F404552900981944C01B522" action="add">
       <border_width>0</border_width>
@@ -151,14 +152,5 @@
     </Relationships>
    </Item>
   </Relationships>
- </Item>
- <Item type="Field" id="9D1DB827227C40B69CFFB1BD6D146F1F" action="edit">
-  <!-- Please note: this AML depends on the "labs_SharePointConfiguration" ItemType. Please make sure it exists before running this. -->
-  <propertytype_id>
-   <Item type="Property" action="get" select="id">
-    <name>itemtype</name>
-    <source_id type="ItemType" keyed_name="labs_SharePointConfiguration">D749BC458188412F850F5FD9E44913CF</source_id>
-   </Item>
-  </propertytype_id>
  </Item>
 </AML>

--- a/Import/SharePointConfiguration/SharePointConfiguration/Import/ItemType/labs_SharePointConfiguration.xml
+++ b/Import/SharePointConfiguration/SharePointConfiguration/Import/ItemType/labs_SharePointConfiguration.xml
@@ -60,6 +60,25 @@
     <track_history>0</track_history>
     <name>itemtype_class</name>
    </Item>
+   <Item type="Property" id="CD947131E8CF4B76A4DE8146D1C7FD18" action="add">
+    <column_alignment>left</column_alignment>
+    <data_source keyed_name="ItemType" type="ItemType" name="ItemType">450906E86E304F55A34B3C0D65C097EA</data_source>
+    <data_type>item</data_type>
+    <is_hidden>0</is_hidden>
+    <is_hidden2>0</is_hidden2>
+    <is_indexed>0</is_indexed>
+    <is_keyed>0</is_keyed>
+    <is_multi_valued>0</is_multi_valued>
+    <is_required>1</is_required>
+    <item_behavior>float</item_behavior>
+    <label xml:lang="en">ItemType</label>
+    <range_inclusive>0</range_inclusive>
+    <readonly>0</readonly>
+    <sort_order>128</sort_order>
+    <source_id keyed_name="labs_SharePointConfiguration" type="ItemType" name="labs_SharePointConfiguration">D749BC458188412F850F5FD9E44913CF</source_id>
+    <track_history>0</track_history>
+    <name>mapped_itemtype</name>
+   </Item>
    <Item type="Property" id="E340A056290C421C97DB5F179DC57BA5" action="add">
     <column_alignment>left</column_alignment>
     <data_type>string</data_type>
@@ -145,29 +164,6 @@
     <related_id keyed_name="labs_SharePointConfiguration" type="Permission">E774D3888AD240A4AF895A69B0676FFF</related_id>
     <sort_order>128</sort_order>
     <source_id keyed_name="labs_SharePointConfiguration" type="ItemType" name="labs_SharePointConfiguration">D749BC458188412F850F5FD9E44913CF</source_id>
-   </Item>
-  </Relationships>
- </Item>
- <Item type="ItemType" id="D749BC458188412F850F5FD9E44913CF" action="edit">
-  <Relationships>
-   <Item type="Property" action="edit" where="source_id='D749BC458188412F850F5FD9E44913CF' and name='itemtype'">
-    <column_alignment>left</column_alignment>
-    <data_source keyed_name="ItemType" type="ItemType" name="ItemType">450906E86E304F55A34B3C0D65C097EA</data_source>
-    <data_type>item</data_type>
-    <is_hidden>0</is_hidden>
-    <is_hidden2>0</is_hidden2>
-    <is_indexed>0</is_indexed>
-    <is_keyed>0</is_keyed>
-    <is_multi_valued>0</is_multi_valued>
-    <is_required>1</is_required>
-    <item_behavior>float</item_behavior>
-    <label xml:lang="en">ItemType</label>
-    <range_inclusive>0</range_inclusive>
-    <readonly>0</readonly>
-    <sort_order>128</sort_order>
-    <source_id keyed_name="labs_SharePointConfiguration" type="ItemType" name="labs_SharePointConfiguration">D749BC458188412F850F5FD9E44913CF</source_id>
-    <track_history>0</track_history>
-    <name>itemtype</name>
    </Item>
   </Relationships>
  </Item>

--- a/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_CreateItemFromSharePoint.xml
+++ b/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_CreateItemFromSharePoint.xml
@@ -50,7 +50,7 @@ var callback = function(spItem) {
     }
     
     // get the ItemType and metadata mapping from the configuration item
-    let itemTypeName = configuration.getPropertyAttribute('itemtype', 'keyed_name', '');
+    let itemTypeName = configuration.getPropertyAttribute('mapped_itemtype', 'keyed_name', '');
     let mappedProperties = configuration.getRelationships('labs_SharePointProperties');
     let new_doc = aras.newIOMItem(itemTypeName, 'add');
 

--- a/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_LoadSharePointDialog.xml
+++ b/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_LoadSharePointDialog.xml
@@ -26,7 +26,7 @@ if (!args.itemTypeId) {
 */
 
 let configurations = aras.newIOMItem('labs_SharePointConfiguration', 'get');
-configurations.setProperty('itemtype', args.itemTypeId);
+configurations.setProperty('mapped_itemtype', args.itemTypeId);
 configurations = configurations.apply();
 if (configurations.isError()) {
     return configurations;

--- a/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_UpdateSharePointMetadata.xml
+++ b/Import/SharePointConfiguration/SharePointConfiguration/Import/Method/labs_UpdateSharePointMetadata.xml
@@ -32,7 +32,7 @@ itemtype = itemtype.apply();
 */
 
 let configurations = aras.newIOMItem('labs_SharePointConfiguration', 'get');
-configurations.setProperty('itemtype', itemtype.getID());
+configurations.setProperty('mapped_itemtype', itemtype.getID());
 configurations.createRelationship('labs_SharePointProperties', 'get');
 configurations = configurations.apply();
 if (configurations.isError()) {


### PR DESCRIPTION
## Description
**What changes are included in this pull request?**
There was a property on labs_SharePointConfiguration called "itemtype" that was causing some import/export issues. Because "itemtype" is a system property name for poly itemtypes, the import/export tools were treating the property as a special case rather than a normal Item property.

The property has been renamed "mapped_itemtype" and all references (form field, method code) have been updated.

## Reason
<!-- Type an x into the square brackets to check the box. -->
- [x] Bug fix
- [ ] Feature enhancement
- [ ] New feature
- [ ] Documentation update
- [ ] Upgrade
- [ ] Other

**Are you responding to a filed Issue? (bug report, feature request, documentation request, etc)**
<!-- If you are submitting a fix for an Issue, reference the issue by number to link it. For example, you can link Issue 5 by entering #5. -->
No

## Testing
### Aras Innovator 
* Major version: 12.0
* Service pack(s): SP0

### Browsers
- [ ] Internet Explorer 11
- [x] Firefox ESR 
- [x] Chrome 
- [x] Edge 

**Does this pull request include known issues?**
<!-- Add details here -->
No new known issues

## Checklist
- [x] Did you confirm the Install Steps in the README are still correct?
- [x] If this PR adds or changes functionality, did you update the Usage Steps in the README?
- [x] Did you add your GitHub user name to the "Credits" section in the README?