### PR TITLE
Fix coordinates of the metadata fields on the Document form

### DIFF
--- a/Import/ExampleImplementation/PLM/Import/Form/Document.xml
+++ b/Import/ExampleImplementation/PLM/Import/Form/Document.xml
@@ -81,7 +81,7 @@
       <sort_order>5760</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>860</x>
+      <x>550</x>
       <y>8</y>
       <z_index>-100</z_index>
       <name>sp_group</name>
@@ -103,7 +103,7 @@
       <sort_order>5248</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>875</x>
+      <x>565</x>
       <y>35</y>
       <z_index>1</z_index>
       <name>sp_id</name>
@@ -125,7 +125,7 @@
       <sort_order>5376</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>875</x>
+      <x>565</x>
       <y>80</y>
       <z_index>1</z_index>
       <name>sp_priority</name>
@@ -147,7 +147,7 @@
       <sort_order>5888</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>875</x>
+      <x>565</x>
       <y>225</y>
       <name>sp_refresh</name>
       <Relationships>
@@ -180,7 +180,7 @@
       <sort_order>5504</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>875</x>
+      <x>565</x>
       <y>125</y>
       <z_index>1</z_index>
       <name>sp_status</name>
@@ -202,7 +202,7 @@
       <sort_order>5632</sort_order>
       <source_id keyed_name="1616C23245254BAD80BECBEC29A02D16" type="Body">1616C23245254BAD80BECBEC29A02D16</source_id>
       <tab_stop>1</tab_stop>
-      <x>875</x>
+      <x>565</x>
       <y>170</y>
       <z_index>1</z_index>
       <name>sp_team</name>


### PR DESCRIPTION
## Description
**What changes are included in this pull request?**
My initial development instance had the XClass selector field enabled, so the spacing looked good on the Document form. However, the spacing looked off when the package was imported into a default Innovator database. 

The metadata field layout has been adjusted for the default Document form.

## Reason
<!-- Type an x into the square brackets to check the box. -->
- [x] Bug fix
- [ ] Feature enhancement
- [ ] New feature
- [ ] Documentation update
- [ ] Upgrade
- [ ] Other

**Are you responding to a filed Issue? (bug report, feature request, documentation request, etc)**
<!-- If you are submitting a fix for an Issue, reference the issue by number to link it. For example, you can link Issue 5 by entering #5. -->
No

## Testing
### Aras Innovator 
* Major version: 12.0 
* Service pack(s): SP0

### Browsers
- [ ] Internet Explorer 11
- [x] Firefox ESR 
- [x] Chrome 
- [x] Edge 

**Does this pull request include known issues?**
<!-- Add details here -->
No new known issues are added.

## Checklist
- [x] Did you confirm the Install Steps in the README are still correct?
- [x] If this PR adds or changes functionality, did you update the Usage Steps in the README?
- [x] Did you add your GitHub user name to the "Credits" section in the README?